### PR TITLE
Change `TaskProgram` and `TaskSchema` to be optional when adding `Task`

### DIFF
--- a/spec/ndx-structured-behavior.extensions.yaml
+++ b/spec/ndx-structured-behavior.extensions.yaml
@@ -71,8 +71,10 @@ groups:
   datasets:
   - neurodata_type_inc: TaskProgram
     doc: A dataset to store a task program.
+    quantity: '?'
   - neurodata_type_inc: TaskSchema
     doc: A dataset to store a task schema, e.g., an XSD file.
+    quantity: '?'
   groups:
   - name: event_types
     neurodata_type_inc: EventTypesTable

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -212,14 +212,14 @@ def main():
                 # name='task_program',
                 neurodata_type_inc='TaskProgram',
                 doc=('A dataset to store a task program.'),
-                # quantity='?'
+                quantity='?'
             ),
             NWBDatasetSpec(
                 # TODO requiring this name is restrictive
                 # name='task_schema',
                 neurodata_type_inc='TaskSchema',
                 doc=('A dataset to store a task schema, e.g., an XSD file.'),
-                # quantity='?'
+                quantity='?'
             ),
         ]
     )


### PR DESCRIPTION
`TaskProgram` and `TaskSchema` should be optional when creating `Task`

Fix #25 
